### PR TITLE
Update index.d.ts

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -7,6 +7,7 @@ interface DOMRectReadOnly {
     readonly right: number;
     readonly bottom: number;
     readonly left: number;
+    toJSON(): any;
 }
 
 declare global {


### PR DESCRIPTION
node_modules/resize-observer-polyfill/src/index.d.ts:19:18 - error TS2717: Subsequent property declarations must have the same type.  Property 'contentRect' must be of type 'DOMRectReadOnly', but here has type 'DOMRectReadOnly'.

19         readonly contentRect: DOMRectReadOnly;
                    ~~~~~~~~~~~

  node_modules/typescript/lib/lib.dom.d.ts:12696:14
    12696     readonly contentRect: DOMRectReadOnly;
                       ~~~~~~~~~~~
    'contentRect' was also declared here.


Found 1 error.

# Description

Short summary of the change.

Relates to https://bettermarks.atlassian.net/browse/BM-

## Type of change

- [ ] Bug fix
- [ ] New feature 
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes

- Test A
- Test B
